### PR TITLE
fix itit typo

### DIFF
--- a/simulate-event.js
+++ b/simulate-event.js
@@ -161,7 +161,7 @@ var eventTypes = {
  * @type {Object}
  */
 var eventInit = {
-  Event:                  'ititEvent',
+  Event:                  'initEvent',
   UIEvent:                'initUIEvent',
   FocusEvent:             'initUIEvent',
   MouseEvent:             'initMouseEvent',
@@ -185,7 +185,7 @@ var eventInit = {
  * @type {Object}
  */
 var eventParameters = {
-  ititEvent: [],
+  initEvent: [],
   initUIEvent: [
     'view',
     'detail'


### PR DESCRIPTION
This fixes a typo `ititEvent` which prevents Event initTypes from being found and throws an .apply error.
